### PR TITLE
Remove gridfit to improve readability on Windows

### DIFF
--- a/koruri.py
+++ b/koruri.py
@@ -67,7 +67,7 @@ def koruri_gasp():
     return (
         (8, ('antialias',)),
         (13, ('antialias', 'symmetric-smoothing')),
-        (65535, ('gridfit', 'antialias', 'symmetric-smoothing', 'gridfit+smoothing')),
+        (65535, ('antialias', 'symmetric-smoothing')),
     )
 
 def generate_koruri(op_path, rb_path, mp_path, ko_path, weight, version):


### PR DESCRIPTION
Windows 環境では Gridfit が含まれているとヒンティングを使用して表示を「改善」しようとしますが、特に HiDPI 環境ではギザギザとした表示になります。
Windows 以外の OS では基本的に無視されており、ヒンティングによる恩恵を受ける環境よりも悪影響を受ける環境の方が多いため、gridfit を gasp より削除します。